### PR TITLE
fix: remove regex check for instance type

### DIFF
--- a/.github/workflows/checkov-analysis.yml
+++ b/.github/workflows/checkov-analysis.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]  
+    branches: [ master ]
   schedule:
     - cron: '19 1 * * 6'
 
@@ -33,4 +33,4 @@ jobs:
 #         uses: github/codeql-action/upload-sarif@v1
 #         with:
 #           # Path to SARIF file relative to the root of the repository
-#           sarif_file: tfsec.sarif 
+#           sarif_file: tfsec.sarif

--- a/variables.tf
+++ b/variables.tf
@@ -152,11 +152,6 @@ variable "instance_tags" {
 variable "instance_type" {
   description = "The type of instance (or launch template) to start. Updates to this field will trigger a stop/start of the EC2 instance, except with launch template."
   default     = "t3.nano"
-
-  validation {
-    condition     = can(regex("^(u-)?[a-z0-9]{2,4}\\.(nano|micro|small|medium|metal|(2|4|8|16|24)?x?large)$", var.instance_type))
-    error_message = "The var.instance_type must match “^(u-)?[a-z0-9]{2,4}\\.(nano|micro|small|medium|metal|(2|4|8|16|24)?x?large)$”."
-  }
 }
 
 variable "ipv4_address_count" {


### PR DESCRIPTION
This regex is not working with instances such as x2iedn.2xlarge and is in my opinion overkill since aws provider will already make this check, with a up-to-date list of instance types